### PR TITLE
Update heise/shariff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,6 @@
   "description": "Integration of the Shariff backend.",
   "type": "drupal-module",
   "require": {
-    "heise/shariff": "^7.0"
+    "heise/shariff": "^8.0"
   }
 }


### PR DESCRIPTION
Update to heise/shariff ^8.0 because of pinterest endpoint is now https. 
https://github.com/heiseonline/shariff-backend-php/commit/45865c3ac1112fc8c608076ce1e498e2e0da9924